### PR TITLE
feat: add expansion tile to story list

### DIFF
--- a/lib/widget.dart
+++ b/lib/widget.dart
@@ -350,42 +350,57 @@ class _StoriesList extends StatelessWidget {
 
     stories.forEach((story) {
       children.add(
-        Text(
-          story.name,
-          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
+        ExpansionTile(
+          title: Text(
+            story.name,
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              fontSize: 20,
+              color: Colors.black,
+            ),
+          ),
+          initiallyExpanded: true,
+          children: story.chapters
+              .map((chapter) => GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        child: _Link(
+                          label: "  ${chapter.name}",
+                          textAlign: TextAlign.left,
+                          padding: EdgeInsets.zero,
+                          height: 20,
+                          textStyle: TextStyle(
+                            fontWeight: chapter.id == selectedChapter.id
+                                ? FontWeight.bold
+                                : FontWeight.normal,
+                          ),
+                        ),
+                      ),
+                    ),
+                    onTap: () {
+                      onSelectChapter(chapter);
+                    },
+                  ))
+              .toList(),
         ),
       );
-      children.add(SizedBox(height: 10));
-
-      story.chapters.forEach((chapter) {
-        children.add(
-          GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            child: _Link(
-              label: "  ${chapter.name}",
-              textAlign: TextAlign.left,
-              padding: EdgeInsets.zero,
-              height: 20,
-              textStyle: TextStyle(
-                fontWeight: chapter.id == selectedChapter.id
-                    ? FontWeight.bold
-                    : FontWeight.normal,
-              ),
-            ),
-            onTap: () {
-              onSelectChapter(chapter);
-            },
-          ),
-        );
-      });
     });
 
-    return SingleChildScrollView(
-      child: Padding(
-        padding: EdgeInsets.all(5),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: children,
+    return Theme(
+      data: Theme.of(context).copyWith(
+        dividerColor: Colors.transparent,
+        accentColor: Colors.black,
+      ),
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: EdgeInsets.all(5),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: children,
+          ),
         ),
       ),
     );

--- a/lib/widget.dart
+++ b/lib/widget.dart
@@ -359,7 +359,6 @@ class _StoriesList extends StatelessWidget {
               color: Colors.black,
             ),
           ),
-          initiallyExpanded: true,
           children: story.chapters
               .map((chapter) => GestureDetector(
                     behavior: HitTestBehavior.opaque,


### PR DESCRIPTION
The purpose of this pull request is to add the ability to expand and collapse story titles.

## Notes

By default, all of the tiles are expanded.  They are also set to the same padding as the tile header.

## Screenshot

![image](https://user-images.githubusercontent.com/57107691/108946518-94adf880-762c-11eb-8e25-bfffc2ecb09d.png)

## Ticket

[SPRFRML-101](https://jira.alkami.com/browse/SPRFRML-101)